### PR TITLE
Fix issues reported from East, WIP!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@
 *.acr
 *.alg
 *.glsdefs
+*.bbl
+*.blg
 *ESF.pdf

--- a/tex/BrakeEncoder.tex
+++ b/tex/BrakeEncoder.tex
@@ -23,13 +23,15 @@ Car is using two pressure sensors as encoders for brake pedal. Each one is for s
 \begin{figure}[H]
 	\begin{center}
 		\includegraphics[width=\textwidth]{./img/BRK-pos.jpg}
-		\caption{Pressure sensor positon.}
+		\caption{Pressure sensor position.}
 		\label{fig:brake_pressure_position}
 	\end{center}
 \end{figure}
 
 \subsection{Brake Encoder Plausibility Check}
-Implausibility is not checked, because eForce does not use brake pedal information to control \glspl{mc}.
+Implausibility between brake sensors is not checked, because e-Force does not use brake pedal information to control \glspl{mc}.
+Electrical signal validity is checked using same circuit an algorithm as \ref{sec:TorqueEncoder}. 
+When brake pedal is pressed and APPS travel is over 25\%, motor torque is set to 0Nm and remain 0Nm until APPS position falls below 5\%. (rule EV 2.4)
 
 %
 %\subsection{Wiring}

--- a/tex/DischargeCircuitry.tex
+++ b/tex/DischargeCircuitry.tex
@@ -1,8 +1,10 @@
 \subsubsection{Description}
 %Describe your concept of the discharge circuitry.
 
-Discharge circuit's purpose is to discharge capacities connected to \gls{ts} voltage and ensure \gls{ts} safety in shutdown state. Such capacities are only in two \glspl{mc}.
+Discharge circuit's purpose is to discharge capacities connected to \gls{ts} and ensure \gls{ts} safety in shutdown state. Such capacities are only in two \glspl{mc}.
 Discharge is activated whenever \gls{sdc} is open. (That means, \gls{acp} is disconnected from \gls{ts} by\glspl{air})
+
+In case of \gls{glvs} power loss, discharge relays immediately close (powered from \gls{glvs}, normally closed contact) and activate discharge circuitry.
 
 \subsubsection{Wiring, cables, current calculations, connectors}
 %\iffalse Describe wiring, show schematics, describe connectors and cables used and show useful data regarding the wiring.

--- a/tex/DischargeCircuitry.tex
+++ b/tex/DischargeCircuitry.tex
@@ -2,7 +2,8 @@
 %Describe your concept of the discharge circuitry.
 
 Discharge circuit's purpose is to discharge capacities connected to \gls{ts} and ensure \gls{ts} safety in shutdown state. Such capacities are only in two \glspl{mc}.
-Discharge is activated whenever \gls{sdc} is open. (That means, \gls{acp} is disconnected from \gls{ts} by\glspl{air})
+
+Discharge is activated whenever \gls{sdc} is open. (That means, \gls{acp} is disconnected from \gls{ts} by\glspl{air}). This behavior is controlled by signal from \gls{ecua} which activates discharge if low \gls{air} is open. Discharge can be forced on (bot not off) by request through CAN. 
 
 In case of \gls{glvs} power loss, discharge relays immediately close (powered from \gls{glvs}, normally closed contact) and activate discharge circuitry.
 

--- a/tex/GroundingConcept.tex
+++ b/tex/GroundingConcept.tex
@@ -1,4 +1,7 @@
 \subsection{Description of the Grounding Concept}
-We are using net of thin wires from grounding point laminated into composite.
+Rear wing is not grounded, there is no \gls{ts} nor \gls{glvs} electronics within 100mm range.
+Front and side wings are grounded with wires that are connected to their (metal) mounting screws and \gls{glvs} ground.
+Steering wheel is grounded using wire connected to \gls{glvs} ground.
+
 \subsection{Grounding Measurements}
-For measuring we are using 4 point method with current power supply to ensure 5 Ohms. In carbon fiber we have copper wires.
+To verify, that our grounding concept is compliant with rules, we are using 4 point resistance measurement method between parts and \gls{glvs} ground with current power supply to ensure resistance below 5 \ohm.

--- a/tex/GroundingConcept.tex
+++ b/tex/GroundingConcept.tex
@@ -1,7 +1,8 @@
 \subsection{Description of the Grounding Concept}
 Rear wing is not grounded, there is no \gls{ts} nor \gls{glvs} electronics within 100mm range.
-Front and side wings are grounded with wires that are connected to their (metal) mounting screws and \gls{glvs} ground.
+Front and side wings are grounded with wires that are connected to their (metal) mounting screws and to \gls{glvs} ground.
 Steering wheel is grounded using wire connected to \gls{glvs} ground.
+All metal parts near \gls{ts} or \gls{glvs} electronics are grounded with wires to \gls{glvs} ground.
 
 \subsection{Grounding Measurements}
 To verify, that our grounding concept is compliant with rules, we are using 4 point resistance measurement method between parts and \gls{glvs} ground with current power supply to ensure resistance below 5 \ohm.

--- a/tex/SDC.tex
+++ b/tex/SDC.tex
@@ -8,7 +8,10 @@ Describe your concept of the shutdown circuit, the master switches, shut down bu
 Additionally, fill out the following table replacing the values with your specification and append additional switches from your setup:
 \fi
 
-\Acrfull{sdc} starts in \gls{ecup}, then goes through all \gls{sdc} elements in the car and ends in \gls{ecua}, which is placed inside the Accumulator Pack. In \gls{ecup}, \gls{sdc} starts from \gls{lv} power +24V and ends in \gls{acp} by powering \gls{air} coils switching circuit (See \ref{fig:SDC-scheme}). The \gls{sdc} consists of 2 master switches, 3 \acrfullpl{sdb}, the (\acrfull{bots}), (\acrfull{imd}, the inertia switch, the \acrfull{bspd}, interlocks in \acrfullpl{mc} and \acrfull{acp} and the accumulator management system (\gls{ams}) and \gls{fwil}. \gls{fwil} triggers shutdown circuit in case of front suspension failure(see \ref{fig:fwil_scheme}). 
+\Acrfull{sdc} starts in \gls{ecup}, then goes through all \gls{sdc} elements in the car and ends in \gls{ecua}, which is placed inside the Accumulator Pack. In \gls{ecup}, \gls{sdc} starts from \gls{lv} power +24V and ends in \gls{acp} by powering \gls{air} coils switching circuit (See \ref{fig:SDC-scheme}). The \gls{sdc} consists of 2 master switches, 3 \acrfullpl{sdb}, the (\acrfull{bots}), (\acrfull{imd}, the inertia switch, the \acrfull{bspd}, interlocks in \acrfullpl{mc} and \acrfull{acp} and the accumulator management system (\gls{ams}) and \gls{fwil}. \gls{fwil} triggers shutdown circuit in case of front suspension failure(see \ref{fig:fwil_scheme}).
+
+Last closing element in \gls{sdc} is switch controlled by \gls{ecub}, which requires pressing TS ON button to close \gls{sdc}.
+This action is required after every \gls{sdc} break event, including car startup.
 
 \begin{figure}[H]
 	\includegraphics[width=\textwidth]{./img/fwil.png}

--- a/tex/TorqueEncoder.tex
+++ b/tex/TorqueEncoder.tex
@@ -31,6 +31,8 @@ Analog input circuitry of \gls{ecup} is shown in \ref{fig:ecup_analog_input}. In
 
 When \gls{adc} measures 0V or value close to 0V, TEST signal logic level is switched \textit{high} to charge $C_1$ through $R_3$. After short while, logic level of TEST signal is read back. If \textit{high} logic level is read, sensor input is evaluated as \textit{open circuit}, otherwise it is \textit{short circuit} to GND. If measured value is close to power voltage of sensor or above measurable range, it is evaluated as \textit{short circuit} to power voltage or higher.
 
+To recognize short between signals of both sensors (rule \textit{T 10.3.6}), one potentiometer has resistor in series to achieve different transfer function (gradient). 
+
 \paragraph{Implausibility}
 Position values difference is calculated and compared with maximal allowed error threshold (10\%).
 

--- a/tex/acronym.tex
+++ b/tex/acronym.tex
@@ -35,7 +35,7 @@
 \newacronym{bms}{BMS}{battery management system}
 \newacronym{ntc}{NTC}{negative temperature coeffitient}
 \newacronym{pcb}{PCB}{printed circuit board}
-\newacronym{glvs}{GLV}{grounded low voltage system}
+\newacronym{glvs}{GLVS}{grounded low voltage system}
 \newacronym{hw}{HW}{hardware}
 \newacronym{fw}{FW}{firmware}
 \newacronym{pmsm}{PMSM}{permanent magnet synchornous motor}


### PR DESCRIPTION
- [x] 2 **CH 10**
How the auxiliary parts of the car are grounded? Eg. aerodynamic wing?
   - some changes in e69348b might need improvement
   - finished in 32e418c

- [x] 3 **CH 11**
How the firewall is grounded? 
   - fixed in e408554ccabe8d2d7a3de59f08fb40ee5c78b3c0

- [x] 4 **CH  2.1.1**
Your system does not fulfill EV5.11.2, no additional action is described.
   - fixed in 48c18d2, mentioned TS ON

- [x] 5 **CH  2.6.1**
You must add an interlock to all wheels with outboard motors according to EV5.4.3

- [x] 6 **CH  2.10.1** (Consult Needed)
You activate discharge based on a CAN message, this is totally unsatisfactory. It won't discharge if you switch off the car with GLVMS. 
   - some changes including GLVS power loss behavior 32e29e5
   - finished in eada2fb

- [x] 7 **CH  2.10.2** (Consult Needed)
Discharge relay (footnote): When you close it, it must handle maximum TS voltage (400V), this relay won't last too long.
   - new relay (already in version to Neth.) can handle 220 V DC per contact, 2 contacts in series, no changes

- [x] 8 **CH  2.12.1**
The described entering mechanism to Ready-to-Drive-Move does not fulfill EV5.11.5

- [x] 9 **CH 4**
Please provide a comprehensive schematic diagram how does the energy meter sensor and datalogger is connected to the car electric system (both LV and HV subsystem). Also provide
information where do you use custom cable or cable provided by the organizer. Please read the
most recent data logger specification to avoid a possible misapprehension, the FS East data logger
will be used (not the FSG data logger).

- [ ] 10 **CH 3.2**
Please provide information about over and undervoltage protection!

- [ ] 11 **CH 7**
If test is connected to GND, then in case of open circuit the signal level on the AIN pin is low, not high. Please correct this part. The sensors must have different transfer function, please give
information about this in your car.
   -  transfer fcn fixed in 3f954d0 

- [x] 12 **CH 8**
Your car doesn't fulfill the rule EV2.4
   - fixed in dd0254d 

- [x] 13 **CH 3.1.5**
Please provide images about the galvanic isolation barrier in the PCB layout.
   - images added 9547a1a
   - inserted in document 0bb08245b0abbcfd1702005adc6c3b74c2171793

- [x] 14 **CH 3.1.7**
If the black material is plastic in the maintenance plug assembly, then you have a compressible material in the high current path, which is prohibited by EV 5.5.6.